### PR TITLE
Bump Action checkout to v3

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ubuntu-latest]
     environment: rubygems-publish
     steps:
-    - uses: zendesk/checkout@v2
+    - uses: zendesk/checkout@v3
     - name: Set up Ruby
       uses: zendesk/setup-ruby@v1
       with:


### PR DESCRIPTION
Bumping the version to resolve the Node.js 12 deprecation warning.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
