### PR TITLE
Publication to npmjs

### DIFF
--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -23,44 +23,49 @@ jobs:
     runs-on: [ubuntu-latest]
     environment: npm-publish
     steps:
-    - uses: zendesk/checkout@v3
-    - name: Set up Node.js
-      uses: zendesk/setup-node@v3
-      with:
-        node-version: ${{ inputs.node_version }}
+      - uses: zendesk/checkout@v3
+      - name: Set up Node.js
+        uses: zendesk/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
 
-    - id: find-yarn-cache-folder
-      name: Find Yarn's cache folder
-      run: echo "::set-output name=path::$(yarn config get cacheFolder)"
-    - name: Cache Yarn's cache folder
-      uses: zendesk/cache@v3.2.5
-      with:
-        path: ${{ steps.find-yarn-cache-folder.outputs.path }}
-        key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
-          yarn-cache-folder-os-${{ runner.os }}-
+      - id: find-yarn-cache-folder
+        name: Find Yarn's cache folder
+        run: echo "::set-output name=path::$(yarn config get cacheFolder)"
+      - name: Cache Yarn's cache folder
+        uses: zendesk/cache@v3.2.5
+        with:
+          path: ${{ steps.find-yarn-cache-folder.outputs.path }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
 
-    - name: Install oauth
-      run: |
-        sudo apt-get install --fix-broken --yes oathtool
+      - name: Install oauth
+        run: |
+          sudo apt-get install --fix-broken --yes oathtool
 
-    - name: Build and release
-      run: |
-        yarn install --immutable
-        yarn build
-        echo -e '\nnpmRegistryServer: "https://registry.npmjs.org"' >> .yarnrc.yml
-        echo 'npmAuthToken: $NPM_TOKEN' >> .yarnrc.yml
-        echo 'npmAlwaysAuth: true' >> .yarnrc.yml
-        totp=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
-        yarn ${{ inputs.command }} --otp $totp
+      - name: Setup yarn
+        run: |
+          yarn config set npmPublishAccess public
+          yarn config set npmAlwaysAuth true
+          yarn config set npmRegistryServer https://registry.npmjs.org
+          yarn config set npmAuthToken $NPM_TOKEN
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+      - name: Build and release
+        run: |
+          yarn install --immutable
+          yarn build
+          totp=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
+          yarn ${{ inputs.command }} --otp $totp
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
 
 
-    - name: Clear the .yarnrc.yml file
-      if: always()
-      run: cat .yarnrc.yml | sed -n -e :a -e '1,4!{P;N;D;};N;ba' > .yarnrc.yml
+      - name: Clear the .yarnrc.yml file
+        if: always()
+        run: rm -f .yarnrc.yml

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -10,9 +10,11 @@ on:
       command:
         required: false
         type: string
-        default: 'publish'
+        default: 'npm publish'
     secrets:
       NPM_TOKEN:
+        required: true
+      NPM_TOTP_DEVICE:
         required: true
 
 jobs:
@@ -39,16 +41,26 @@ jobs:
           yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
           yarn-cache-folder-os-${{ runner.os }}-
 
+    - name: Install oauth
+      run: |
+        sudo apt-get install --fix-broken --yes oathtool
+
     - name: Build and release
       run: |
         yarn install --immutable
         yarn build
-        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        yarn ${{ inputs.command }}
-      env:
-        NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        echo -e '\nnpmRegistryServer: "https://registry.npmjs.org"' >> .yarnrc.yml
+        echo 'npmAuthToken: $NPM_TOKEN' >> .yarnrc.yml
+        echo 'npmAlwaysAuth: true' >> .yarnrc.yml
+        totp=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
+        yarn ${{ inputs.command }} --otp $totp
 
-    - name: Delete npmrc
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+
+
+    - name: Clear the .yarnrc.yml file
       if: always()
-      run: rm ~/.npmrc
+      run: cat .yarnrc.yml | sed -n -e :a -e '1,4!{P;N;D;};N;ba' > .yarnrc.yml

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: 'npm publish'
+      publicize:
+        required: false
+        type: boolean
+        default: true
     secrets:
       NPM_TOKEN:
         required: true
@@ -48,7 +52,7 @@ jobs:
       - name: Setup yarn
         run: |
           yarn config set npmPublishAccess public
-          yarn config set npmAlwaysAuth true
+          yarn config set npmAlwaysAuth ${{ inputs.publicize }}
           yarn config set npmRegistryServer https://registry.npmjs.org
           yarn config set npmAuthToken $NPM_TOKEN
         env:

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -1,0 +1,51 @@
+name: NPM Package Publication
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        required: false
+        type: string
+        default: '16'
+      command:
+        required: false
+        type: string
+        default: 'publish'
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: [ubuntu-latest]
+    environment: npm-publish
+    steps:
+    - uses: zendesk/checkout@v3
+    - name: Set up Node.js
+      uses: zendesk/setup-node@v3
+      with:
+        node-version: ${{ inputs.node_version }}
+
+    - id: find-yarn-cache-folder
+      name: Find Yarn's cache folder
+      run: echo "::set-output name=path::$(yarn config get cacheFolder)"
+    - name: Cache Yarn's cache folder
+      uses: zendesk/cache@v3.2.5
+      with:
+        path: ${{ steps.find-yarn-cache-folder.outputs.path }}
+        key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+          yarn-cache-folder-os-${{ runner.os }}-
+
+    - name: Build and release
+      run: |
+        yarn install --immutable
+        yarn build
+        echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+        yarn ${{ inputs.command }}
+        rm ~/.npmrc
+      env:
+        NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -55,8 +55,12 @@ jobs:
 
       - name: Setup yarn
         run: |
-          yarn config set npmPublishAccess public
-          yarn config set npmAlwaysAuth ${{ inputs.publicize }}
+          if {{ inputs.publicize }}; then
+            yarn config set npmPublishAccess public
+          else
+            yarn config set npmPublishAccess restricted
+          fi
+          yarn config set npmAlwaysAuth true
           yarn config set npmRegistryServer https://registry.npmjs.org
           yarn config set npmAuthToken $NPM_TOKEN
         env:

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -45,7 +45,10 @@ jobs:
         yarn build
         echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
         yarn ${{ inputs.command }}
-        rm ~/.npmrc
       env:
         NPM_TOKEN: ${{secrets.NPM_TOKEN}}
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Delete npmrc
+      if: always()
+      run: rm ~/.npmrc

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -40,11 +40,12 @@ jobs:
 
       - id: find-yarn-cache-folder
         name: Find Yarn's cache folder
-        run: echo "::set-output name=path::$(yarn config get cacheFolder)"
+        run: echo "YARN_CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_ENV
+
       - name: Cache Yarn's cache folder
         uses: zendesk/cache@v3.2.5
         with:
-          path: ${{ steps.find-yarn-cache-folder.outputs.path }}
+          path: ${{ env.YARN_CACHE_FOLDER }}
           key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: 'npm publish'
+      commit:
+        required: false
+        type: boolean
+        default: false
       publicize:
         required: false
         type: boolean
@@ -58,6 +62,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Git config user
+        run: |
+          git config user.name zendesk-ops-ci
+          git config user.email zendesk-ops-ci@users.noreply.github.com
+
       - name: Build and release
         run: |
           yarn install --immutable
@@ -69,6 +78,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
 
+      - name: Git push
+        if: ${{ inputs.commit }}
+        run: |
+          git push origin ${{ github.head_ref || github.ref_name }}
 
       - name: Clear the .yarnrc.yml file
         if: always()

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         yarn install --immutable
         yarn build
-        echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
         yarn ${{ inputs.command }}
       env:
         NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -36,6 +36,11 @@ jobs:
         uses: zendesk/setup-node@v3
         with:
           node-version: ${{ inputs.node_version }}
+      # Use yarn2
+      - name: Install Yarn
+        run: npm install -g yarn
+      - name: Set Yarn Version
+        run: yarn set version berry
 
       - id: find-yarn-cache-folder
         name: Find Yarn's cache folder

--- a/.github/workflows/npm-publication.yml
+++ b/.github/workflows/npm-publication.yml
@@ -15,10 +15,6 @@ on:
         required: false
         type: boolean
         default: false
-      publicize:
-        required: false
-        type: boolean
-        default: true
     secrets:
       NPM_TOKEN:
         required: true
@@ -60,11 +56,7 @@ jobs:
 
       - name: Setup yarn
         run: |
-          if {{ inputs.publicize }}; then
-            yarn config set npmPublishAccess public
-          else
-            yarn config set npmPublishAccess restricted
-          fi
+          yarn config set npmPublishAccess public
           yarn config set npmAlwaysAuth true
           yarn config set npmRegistryServer https://registry.npmjs.org
           yarn config set npmAuthToken $NPM_TOKEN

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -1,0 +1,91 @@
+# Publish a Gem to NPMJS
+
+A workflow for publishing your package to NPM. This publishes to the **public** Zendesk NPM account. This requires you
+have a `package.json` file in the root of the repository configured for publishing.
+
+## Workflow file
+
+This is the location of the workflow file relative to this repository you will need to use.
+
+`.github/workflows/npm-publication.yml`
+
+## Required inputs
+
+| Input               | Description                                                                                                                           |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `secrets.NPM_TOKEN` | required, The environment secret containing the NPM API key                                                                           |
+| `node_version`      | optional, default `16`, Version of node to be used with the build.                                                                    |
+| `command`           | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
+
+## How to use
+
+To use this workflow you should create a workflow in your repository calling this re-usable workflow. Please see an
+example of this below. You will need to setup an environment within your repository called `npm-publish`. Where you will
+need to request for a NPM API key to be added with the name of `NPM_TOKEN`.
+
+## Example usage
+
+Here is an example workflow that will use the default publish command.
+
+```yml
+name: npm publish
+on:
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/npm-publication.yml@master
+    with:
+      node_version: '16'
+    secrets:
+      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+```
+
+Alternatively you can use any versioning command in `package.json` to automatically update the version number. You can
+use this command in the `command` input.
+
+```yml
+name: npm publish
+on:
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/npm-publication.yml@master
+    with:
+      node_version: '16'
+      command: 'release'
+    secrets:
+      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+```
+
+```json
+{
+  [...]
+  "scripts": {
+    [...]
+    "release": "beemo run-script release"
+  },
+  "release": {
+    "tagFormat": "${version}",
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "master",
+      {
+        "name": "main",
+        "channel": false
+      },
+      "next",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ]
+  }
+[...]
+}
+```

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -41,7 +41,7 @@ jobs:
       NPM_TOKEN: ${{secrets.NPM_TOKEN}}
 ```
 
-Alternatively you can use any versioning command in `package.json` to automatically update the version number. You can
+Alternatively you can use any versioning command in `package.json` to automatically bump the version number. You can
 use this command in the `command` input.
 
 ```yml

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -18,7 +18,6 @@ This is the location of the workflow file relative to this repository you will n
 | `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                  |
 | `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
 | `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).        |
-| `publicize`                | optional, default `true`. Upload the package as public. Disable for testing purposes only.                                          |
 
 ## How to use
 

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -17,6 +17,7 @@ This is the location of the workflow file relative to this repository you will n
 | `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
 | `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                    |
 | `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
+| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).          |
 | `publicize`                | optional, default `true`. Upload the package as private. For testing purposes only.                                                   |
 
 ## How to use
@@ -98,7 +99,24 @@ jobs:
 Another example with `npm version patch` command.
 
 ```yml
+name: upload
+on:
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
+    with:
+      node_version: '16'
+      command: 'releaseee'
+      commit: true
+    secrets:
+      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+      NPM_TOTP_DEVICE: ${{secrets.NPM_TOTP_DEVICE}}
+```
+
+```yml
 "scripts": {
-    "release": "npm version patch --force && npm publish"
+    "release": "npm version patch --force && yarn npm publish"
   }
 ```

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -17,6 +17,7 @@ This is the location of the workflow file relative to this repository you will n
 | `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
 | `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                    |
 | `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
+| `publicize`                | optional, default `true`. Upload the package as private. For testing purposes only.                                                   |
 
 ## How to use
 
@@ -35,7 +36,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: zendesk/gw/.github/workflows/npm-publication.yml@master
+    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
     with:
       node_version: '16'
     secrets:
@@ -54,7 +55,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: zendesk/gw/.github/workflows/npm-publication.yml@master
+    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
     with:
       node_version: '16'
       command: 'release'
@@ -92,4 +93,12 @@ jobs:
   }
 [...]
 }
+```
+
+Another example with `npm version patch` command.
+
+```yml
+"scripts": {
+    "release": "npm version patch --force && npm publish"
+  }
 ```

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -22,7 +22,7 @@ This is the location of the workflow file relative to this repository you will n
 
 To use this workflow you should create a workflow in your repository calling this re-usable workflow. Please see an
 example of this below. You will need to setup an environment within your repository called `npm-publish`. Where you will
-need to request for a NPM API key to be added with the name of `NPM_TOKEN`.
+need to request for a NPM API key to be added with the name of `NPM_TOKEN` and the 2FA secret `NPM_TOTP_DEVICE`.
 
 ## Example usage
 

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -1,7 +1,7 @@
 # Publish a Gem to NPMJS
 
 A workflow for publishing your package to NPM. This publishes to the **public** Zendesk NPM account. This requires you
-have a `package.json` file in the root of the repository configured for publishing.
+have a `package.json` file in the root of the repository configured for publishing and `.yarnrc.yaml` file with the nodeLinker set.
 
 ## Workflow file
 
@@ -11,11 +11,12 @@ This is the location of the workflow file relative to this repository you will n
 
 ## Required inputs
 
-| Input               | Description                                                                                                                           |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `secrets.NPM_TOKEN` | required, The environment secret containing the NPM API key                                                                           |
-| `node_version`      | optional, default `16`, Version of node to be used with the build.                                                                    |
-| `command`           | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
+| Input                      | Description                                                                                                                           |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `secrets.NPM_TOKEN`        | required, The environment secret containing the NPM API key                                                                           |
+| `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
+| `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                    |
+| `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
 
 ## How to use
 
@@ -39,6 +40,8 @@ jobs:
       node_version: '16'
     secrets:
       NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+      NPM_TOTP_DEVICE: ${{secrets.NPM_TOTP_DEVICE}}
+
 ```
 
 Alternatively you can use any versioning command in `package.json` to automatically bump the version number. You can
@@ -57,6 +60,7 @@ jobs:
       command: 'release'
     secrets:
       NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+      NPM_TOTP_DEVICE: ${{secrets.NPM_TOTP_DEVICE}}
 ```
 
 ```json

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -11,14 +11,14 @@ This is the location of the workflow file relative to this repository you will n
 
 ## Required inputs
 
-| Input                      | Description                                                                                                                           |
-|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `secrets.NPM_TOKEN`        | required, The environment secret containing the NPM API key                                                                           |
-| `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
-| `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                    |
+| Input                      | Description                                                                                                                         |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `secrets.NPM_TOKEN`        | required, The environment secret containing the NPM API key                                                                         |
+| `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                            |
+| `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                  |
 | `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
-| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).          |
-| `publicize`                | optional, default `true`. Upload the package as private. For testing purposes only.                                                   |
+| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).        |
+| `publicize`                | optional, default `true`. Upload the package as public. Disable for testing purposes only.                                          |
 
 ## How to use
 

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -1,23 +1,28 @@
-# Publish a Gem to NPMJS
+# Publish a Package to NPMJS
 
 A workflow for publishing your package to NPM. This publishes to the **public** Zendesk NPM account. This requires you
-have a `package.json` file in the root of the repository configured for publishing and `.yarnrc.yaml` file with the nodeLinker set.
+have a `package.json` file in the root of the repository configured for publishing and `.yarnrc.yaml` file with the
+nodeLinker set.
 
 ## Workflow file
 
-This is the location of the workflow file relative to this repository you will need to use.
+This is the location of the workflow file relative to this repository:
 
 `.github/workflows/npm-publication.yml`
 
+To call it from your repository you'll need to use: 
+
+`zendesk/gw/.github/workflows/npm-publication.yml@main`
+
 ## Required inputs
 
-| Input                      | Description                                                                                                                         |
-|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `secrets.NPM_TOKEN`        | required, The environment secret containing the NPM API key                                                                         |
-| `secrets.NPM_TOTP_DEVICE`	 | required, The organization secret containing the NPMJS API key TOTP Code                                                            |
-| `node_version`             | optional, default `16`, Version of node to be used with the build.                                                                  |
-| `command`                  | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
-| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).        |
+| Input                     | Description                                                                                                                           |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `secrets.NPM_TOKEN`       | required, The environment secret containing the NPM API key                                                                           |
+| `secrets.NPM_TOTP_DEVICE` | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
+| `node_version`            | optional, default `16`, Version of node to be used with the build.                                                                    |
+| `command`                 | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
+| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).          |
 
 ## How to use
 
@@ -25,9 +30,11 @@ To use this workflow you should create a workflow in your repository calling thi
 example of this below. You will need to setup an environment within your repository called `npm-publish`. Where you will
 need to request for a NPM API key to be added with the name of `NPM_TOKEN` and the 2FA secret `NPM_TOTP_DEVICE`.
 
+Your workflow should have a valid `build` command in the `package.json` file. This will be used to build the package.
+
 ## Example usage
 
-Here is an example workflow that will use the default publish command.
+Here is an example workflow that will use the default `publish` command.
 
 ```yml
 name: npm publish
@@ -45,57 +52,11 @@ jobs:
 
 ```
 
-Alternatively you can use any versioning command in `package.json` to automatically bump the version number. You can
-use this command in the `command` input.
+Alternatively you can use any versioning command in `package.json` to automatically bump the version number. You can use
+this command in the `command` input.
 
-```yml
-name: npm publish
-on:
-  workflow_dispatch:
-
-jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
-    with:
-      node_version: '16'
-      command: 'release'
-    secrets:
-      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-      NPM_TOTP_DEVICE: ${{secrets.NPM_TOTP_DEVICE}}
-```
-
-```json
-{
-  [...]
-  "scripts": {
-    [...]
-    "release": "beemo run-script release"
-  },
-  "release": {
-    "tagFormat": "${version}",
-    "branches": [
-      "+([0-9])?(.{+([0-9]),x}).x",
-      "master",
-      {
-        "name": "main",
-        "channel": false
-      },
-      "next",
-      {
-        "name": "beta",
-        "prerelease": true
-      },
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
-    ]
-  }
-[...]
-}
-```
-
-Another example with `npm version patch` command.
+This example uses `npm version patch` command to automatically bump the version. 
+The `commit` input is set to `true` to automatically commit the changes with the `zendesk-ops-ci` service account.
 
 ```yml
 name: upload
@@ -106,8 +67,8 @@ jobs:
   call-workflow:
     uses: zendesk/gw/.github/workflows/npm-publication.yml@main
     with:
-      node_version: '16'
-      command: 'releaseee'
+      node_version: '19'
+      command: 'release'
       commit: true
     secrets:
       NPM_TOKEN: ${{secrets.NPM_TOKEN}}
@@ -115,7 +76,11 @@ jobs:
 ```
 
 ```yml
-"scripts": {
+  "main": "src/index.js",
+  "scripts": {
+    "build": "node src/index.js",
     "release": "npm version patch --force && yarn npm publish"
   }
 ```
+
+

--- a/npm-package-publication/README.md
+++ b/npm-package-publication/README.md
@@ -16,13 +16,13 @@ To call it from your repository you'll need to use:
 
 ## Required inputs
 
-| Input                     | Description                                                                                                                           |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `secrets.NPM_TOKEN`       | required, The environment secret containing the NPM API key                                                                           |
-| `secrets.NPM_TOTP_DEVICE` | required, The organization secret containing the NPMJS API key TOTP Code                                                              |
-| `node_version`            | optional, default `16`, Version of node to be used with the build.                                                                    |
-| `command`                 | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number change. |
-| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).          |
+| Input                     | Description                                                                                                                         |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `secrets.NPM_TOKEN`       | required, The environment secret containing the NPM API key                                                                         |
+| `secrets.NPM_TOTP_DEVICE` | required, The organization secret containing the NPMJS API key TOTP Code                                                            |
+| `node_version`            | optional, default `16`, Version of Node to be used with the build.                                                                  |
+| `command`                 | optional, default `publish`. Command to be used with yarn to publish the package. Can be used to set automatic version number bump. |
+| `commit`                  | optional, default `false`. Pushes the commit that might have been generated during the build. See [example](#Example-usage).        |
 
 ## How to use
 


### PR DESCRIPTION
Standardize the publication to NPMJS packages between Zendesk repositories. It uses the `yarn` package manager for deployment.

The command to use is passed with inputs. This is caused by different versioning solutions used by repositories.