### PR TITLE
Use GEM_HOST_API_KEY

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -31,14 +31,9 @@ jobs:
 
     - name: Publish to RubyGems
       run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${RUBY_GEMS_API_KEY}\n" > $HOME/.gem/credentials
         gem build *.gemspec
         totp=$(oathtool --base32 --totp "${RUBY_GEMS_TOTP_DEVICE}")
         gem push *.gem --otp "$totp"
-        rm -rf $HOME/.gem/credentials
       env:
-        RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+        GEM_HOST_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
         RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
`gem help push` reads

> [...]
>
> The push command will use ~/.gem/credentials to authenticate to a server,
> but you can use the RubyGems environment variable GEM_HOST_API_KEY to set
> the api key to authenticate.

So using the ENV variable that is already available, we don't need the hassle of creating a temporary file.

Another thing is, in Rubygems source code I found that we could use GEM_HOST_OTP_CODE instead of passing the `--otp` flag. But since the otp value is currently not shared outside the "Publish to RubyGems" step, storing that value in an ENV variable might actually decrease security.