### PR TITLE
Add a workflow for publishing gems to Artifactory

### DIFF
--- a/.github/workflows/artifactory-gem-publication.yml
+++ b/.github/workflows/artifactory-gem-publication.yml
@@ -1,0 +1,39 @@
+name: Publish Gem to private gem server (Artifactory)
+
+on:
+  workflow_call:
+    inputs:
+      ruby_version:
+        required: false
+        type: string
+        default: '3.2'
+    secrets:
+      ARTIFACTORY_API_KEY:
+        required: true
+      ARTIFACTORY_USERNAME:
+        required: true
+
+jobs:
+  build:
+    name: Build and publish gem
+    runs-on: [ubuntu-latest]
+    environment: artifactory-publish
+    steps:
+    - uses: zendesk/checkout@v3
+    - name: Set up Ruby
+      uses: zendesk/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby_version }}
+
+    - name: Publish to Artifactory
+      run: |
+        mkdir -p $HOME/.gem
+        curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_API_KEY \
+          https://zdrepo.jfrog.io/artifactory/api/gems/gems-local/api/v1/api_key.yaml > $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem --host https://zdrepo.jfrog.io/artifactory/api/gems/gems-local
+        rm -f $HOME/.gem/credentials
+      env:
+        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: Publish Gem to public gem server
 
 on:
   workflow_call:
@@ -6,7 +6,7 @@ on:
       ruby_version:
         required: false
         type: string
-        default: '2.6'
+        default: '3.2'
     secrets:
       RUBY_GEMS_API_KEY:
         required: true
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: Build + Publish
+    name: Build and publish gem
     runs-on: [ubuntu-latest]
     environment: rubygems-publish
     steps:

--- a/artifactory-gem-publication/README.md
+++ b/artifactory-gem-publication/README.md
@@ -1,0 +1,40 @@
+# Publish a Gem to RubyGems
+
+A workflow for publishing your Gem to out **private** Artifactory gem server. This requires you have a `.gemspec` file in the root of the repository configured with the correct values for publishing.
+
+## Workflow file
+
+This is the location of the workflow file relative to this repository you will need to use.
+
+`.github/workflows/artifactory-gem-publication.yml`
+
+## Required inputs
+
+| Input                          | Description                                                            |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `secrets.ARTIFACTORY_API_KEY`  | required, The organization secret containing the Artifactory API key   |
+| `secrets.ARTIFACTORY_USERNAME` | required, The organization secret containing the Artifactory user name |
+| `RUBY_VERSION`                 | optional, default `3.2`, Version of ruby to be used with the build.    |
+
+## How to use
+
+To use this workflow you should create a workflow in your repository calling this re-usable workflow. Please see an example of this below. If you want to limit _who_ can run the workflow, you will need to set up an environment within your repository called `artifactory-publish`.
+
+## Example usage
+
+Here is an example workflow that will run when a commit is tagged with something begining with `v`
+
+```
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/artifactory-gem-publication.yml@main
+    secrets:
+      ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+      ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+```

--- a/ruby-gem-publication/README.md
+++ b/ruby-gem-publication/README.md
@@ -11,14 +11,14 @@ This is the location of the workflow file relative to this repository you will n
 ## Required inputs
 
 | Input                             | Description                                                                 |
-| --------------------------------- | ----------------------------------------------------------------------------|
-| `secrets.RUBY_GEMS_API_KEY`     | required, The environment secret containing the RubyGems API key            |
+| --------------------------------- | --------------------------------------------------------------------------- |
+| `secrets.RUBY_GEMS_API_KEY`       | required, The environment secret containing the RubyGems API key            |
 | `secrets.RUBY_GEMS_TOTP_DEVICE`   | required, The organization secret containing the RubyGems API key TOTP Code |
-| `RUBY_VERSION`                    | optional, default `2.6`, Version of ruby to be used with the build.         |
+| `RUBY_VERSION`                    | optional, default `3.2`, Version of ruby to be used with the build.         |
 
 ## How to use
 
-To use this workflow you should create a workflow in your repository calling this re-usable workflow. Please see an example of this below. You will need to request permissions for your repository to access a secret `RUBY_GEMS_TOTP_DEVICE` from your repository. You will also need to setup an environment within your repository called `rubygems-publish`. Where you will need to request for a RubyGems API key to be added with the name of `RUBY_GEMS_API_KEY`.
+To use this workflow you should create a workflow in your repository calling this re-usable workflow. Please see an example of this below. You will need to request permissions for your repository to access a secret `RUBY_GEMS_TOTP_DEVICE` from your repository. You will also need to set up an environment within your repository called `rubygems-publish` where you will need to request for a RubyGems API key to be added with the name of `RUBY_GEMS_API_KEY`.
 
 ## Example usage
 


### PR DESCRIPTION
Blocked by #4.

Heavily inspired by [./ruby-gem-publication.yml](https://github.com/zendesk/gw/blob/796c0714484cbe1366bbefed25b34330e24b7e03/.github/workflows/ruby-gem-publication.yml) and [a similar workflow in the zendesk/sell-fs-api repository](https://github.com/zendesk/sell-fs-api/blob/c1e9e9c8ab6e43579fa02ea306873bac2aba06cd/.github/workflows/publish_to_artifactory.yml).

This commit also changes ./ruby-gem-publication.yml a bit, so the two workflows can be a bit more similar.
