### PR TITLE
Revert "Use GEM_HOST_API_KEY"

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -31,9 +31,14 @@ jobs:
 
     - name: Publish to RubyGems
       run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${RUBY_GEMS_API_KEY}\n" > $HOME/.gem/credentials
         gem build *.gemspec
         totp=$(oathtool --base32 --totp "${RUBY_GEMS_TOTP_DEVICE}")
         gem push *.gem --otp "$totp"
+        rm -rf $HOME/.gem/credentials
       env:
-        GEM_HOST_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+        RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
         RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
Reverts zendesk/gw#4

As mentioned in the original PR, `gem help push` reads

> [...]
>
> The push command will use ~/.gem/credentials to authenticate to a server,
> but you can use the RubyGems environment variable GEM_HOST_API_KEY to set
> the api key to authenticate.

After seeing a gem push fail today and reading some Rubygems source code, I realized that `GEM_HOST_API_KEY` is used for setting the _key name_, useful if your `~/.gem/credentials` contains credentials for multiple gem servers. You could say that the default value for `GEM_HOST_API_KEY` is `rubygems_api_key`.

Just to make it totally clear how confusing the naming of our credentials hash is:
- Key: `rubygems_api_key`
- Value: `$RUBY_GEMS_API_KEY` 😅 