### PR TITLE
feat: add npm trusted publisher reusable workflow

### DIFF
--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -31,6 +31,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.1
           sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
 
       - name: Validate package json file path and name
@@ -62,11 +62,22 @@ jobs:
         run: |
           set -euo pipefail
           if npm view "$PACKAGE_NAME" version >/dev/null 2>&1; then
+            echo "Package $PACKAGE_NAME exists on npmjs"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Package $PACKAGE_NAME does not exist on npmjs"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
       
+      - name: Set base version
+        if: steps.package-exists.outputs.exists != 'true'
+        env:
+          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
+        run: |
+          set -euo pipefail
+          cd "$(dirname "$PACKAGE_JSON_FILE_PATH")"
+          npm version 0.0.0 --no-git-tag-version --allow-same-version
+
       - name: Initial publish with token
         if: steps.package-exists.outputs.exists != 'true'
         env:
@@ -78,6 +89,8 @@ jobs:
           otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
           npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --access public --otp "$otp"
+          echo "Sleeping for 15 seconds for npmjs to reflect the new $PACKAGE_NAME package, so that the trusted publisher can be configured"
+          sleep 15
 
       - name: Configure trusted publisher
         env:
@@ -94,12 +107,40 @@ jobs:
           curl_args=(-H "Authorization: Bearer $NPM_TOKEN" -H "npm-otp: $otp")
 
           trust="$(curl -fsS "${curl_args[@]}" "$url" 2>/dev/null || echo '[]')"
-          if [[ -n "$trust" && "$trust" != "[]" && "$trust" != "{}" ]]; then
-            echo "Trusted publisher for $PACKAGE_NAME is already configured"
-            exit 0
-          fi
+          plan="$(jq -c \
+            --arg repo "$REPOSITORY" \
+            --arg wf "$PUBLISH_WORKFLOW" \
+            --arg env "$ENVIRONMENT" \
+            --arg pkg "$PACKAGE_NAME" \
+            '
+            def entries: if type == "array" then . elif (type == "object" and . != {}) then [.] else [] end;
+            def matches($e): any($e[]; .type == "github" and .claims.repository == $repo and .claims.workflow_ref.file == $wf and .claims.environment == $env);
+            entries as $e
+            | matches($e) as $matched
+            | {
+                matched: $matched,
+                logs: (
+                  if $matched then
+                    ["Trusted publisher for \($pkg) already matches inputs"]
+                  elif ($e | length) > 0 then
+                    ["Trusted publisher mismatch for \($pkg)"]
+                    + ($e | map("  current: repository=\(.claims.repository) workflow=\(.claims.workflow_ref.file) environment=\(.claims.environment)"))
+                    + ["  expected: repository=\($repo) workflow=\($wf) environment=\($env)"]
+                  else
+                    ["No trusted publisher configured for \($pkg)"]
+                  end
+                ),
+                ids: ($e | map(.id // empty)),
+                body: [{type:"github",claims:{repository:$repo,workflow_ref:{file:$wf},environment:$env},permissions:["createPackage"]}]
+              }
+            ' <<<"${trust:-[]}")"
 
-          body="$(jq -nc --arg repo "$REPOSITORY" --arg wf "$PUBLISH_WORKFLOW" --arg env "$ENVIRONMENT" \
-            '[{type:"github",claims:{repository:$repo,workflow_ref:{file:$wf},environment:$env},permissions:["createPackage"]}]')"
+          jq -r '.logs[]' <<<"$plan"
+          jq -e '.matched' <<<"$plan" >/dev/null && exit 0
 
-          curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$body"
+          while read -r id; do
+            [[ -n "$id" ]] && curl -fsS -X DELETE "${url}/${id}" "${curl_args[@]}"
+          done < <(jq -r '.ids[]' <<<"$plan")
+
+          curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$(jq -c '.body' <<<"$plan")"
+          echo "Trusted publisher for $PACKAGE_NAME configured successfully"

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -86,9 +86,6 @@ jobs:
           NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
         run: |
           set -euo pipefail
-          workflow="${PUBLISH_WORKFLOW#./}"
-          workflow="${workflow#.github/workflows/}"
-          workflow="${workflow##*/}"
           otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
           url="https://registry.npmjs.org/-/package/${PACKAGE_NAME//\//%2F}/trust"
           curl_args=(-H "Authorization: Bearer $NPM_TOKEN" -H "npm-otp: $otp")
@@ -99,7 +96,7 @@ jobs:
             exit 0
           fi
 
-          body="$(jq -nc --arg repo "$REPOSITORY" --arg wf "$workflow" --arg env "$ENVIRONMENT" \
+          body="$(jq -nc --arg repo "$REPOSITORY" --arg wf "$PUBLISH_WORKFLOW" --arg env "$ENVIRONMENT" \
             '[{type:"github",claims:{repository:$repo,workflow_ref:{file:$wf},environment:$env},permissions:["createPackage"]}]')"
 
           curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$body"

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -1,0 +1,105 @@
+name: NPM Trusted Publication
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        required: true
+        type: string
+      package-json-file-path:
+        required: false
+        type: string
+        default: package.json
+      publish-workflow:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+      github-environment:
+        required: false
+        type: string
+        default: npm-publish
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.github-environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.14'
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup
+        run: |
+          npm install -g npm@latest
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
+
+      - name: Validate package json file path and name
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
+        run: |
+          set -euo pipefail
+          [[ "$PACKAGE_JSON_FILE_PATH" != /* ]] || { echo "package-json-file-path must not be an absolute path"; exit 1; }
+          [[ -f "$PACKAGE_JSON_FILE_PATH" ]] || { echo "package-json-file-path does not exist"; exit 1; }
+          [[ "$(node -p "require('./$PACKAGE_JSON_FILE_PATH').name")" == "$PACKAGE_NAME" ]] || { echo "package-name does not match package.json name"; exit 1; }
+      
+      - name: Check if package exists on npm
+        id: package-exists
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if npm view "$PACKAGE_NAME" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      
+      - name: Initial publish with token
+        if: steps.package-exists.outputs.exists != 'true'
+        env:
+          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
+        run: |
+          set -euo pipefail
+          otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --otp "$otp"
+
+      - name: Configure trusted publisher
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          PUBLISH_WORKFLOW: ${{ inputs.publish-workflow }}
+          REPOSITORY: ${{ inputs.repository }}
+          ENVIRONMENT: ${{ inputs.github-environment }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
+        run: |
+          set -euo pipefail
+          workflow="${PUBLISH_WORKFLOW#./}"
+          workflow="${workflow#.github/workflows/}"
+          workflow="${workflow##*/}"
+          otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
+          url="https://registry.npmjs.org/-/package/${PACKAGE_NAME//\//%2F}/trust"
+          curl_args=(-H "Authorization: Bearer $NPM_TOKEN" -H "npm-otp: $otp")
+
+          trust="$(curl -fsS "${curl_args[@]}" "$url" 2>/dev/null || echo '[]')"
+          if [[ -n "$trust" && "$trust" != "[]" && "$trust" != "{}" ]]; then
+            echo "Trusted publisher for $PACKAGE_NAME is already configured"
+            exit 0
+          fi
+
+          body="$(jq -nc --arg repo "$REPOSITORY" --arg wf "$workflow" --arg env "$ENVIRONMENT" \
+            '[{type:"github",claims:{repository:$repo,workflow_ref:{file:$wf},environment:$env},permissions:["createPackage"]}]')"
+
+          curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$body"

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -20,12 +20,12 @@ on:
         required: false
         type: string
         default: npm-publish
-    
-secrets:
-  NPM_TOKEN:
-    required: true
-  NPM_TOTP_DEVICE:
-    required: true
+    secrets:
+      NPM_TOKEN:
+        required: true
+      NPM_TOTP_DEVICE:
+        required: true
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -20,15 +20,8 @@ on:
         required: false
         type: string
         default: npm-publish
-    secrets:
-      NPM_TOKEN:
-        required: true
-      NPM_TOTP_SECRET:
-        required: true
-
 permissions:
   contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -74,10 +67,10 @@ jobs:
         env:
           PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
         run: |
           set -euo pipefail
-          otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
+          otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
           npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --access public --otp "$otp"
 
@@ -88,10 +81,10 @@ jobs:
           REPOSITORY: ${{ inputs.repository }}
           ENVIRONMENT: ${{ inputs.github-environment }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
         run: |
           set -euo pipefail
-          otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
+          otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
           url="https://registry.npmjs.org/-/package/${PACKAGE_NAME//\//%2F}/trust"
           curl_args=(-H "Authorization: Bearer $NPM_TOKEN" -H "npm-otp: $otp")
 

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -20,6 +20,12 @@ on:
         required: false
         type: string
         default: npm-publish
+    
+secrets:
+  NPM_TOKEN:
+    required: true
+  NPM_TOTP_DEVICE:
+    required: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -60,15 +60,14 @@ jobs:
         id: package-exists
         env:
           PACKAGE_NAME: ${{ inputs.package-name }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-          if npm view "$PACKAGE_NAME" version >/dev/null 2>&1; then
+          encoded="${PACKAGE_NAME//\//%2F}"
+          if curl -fsS "https://registry.npmjs.org/${encoded}" >/dev/null; then
             echo "Package $PACKAGE_NAME exists on npmjs"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Package $PACKAGE_NAME does not exist on npmjs"
+            echo "Package $PACKAGE_NAME is not currently published on npmjs"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
       

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -61,6 +61,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           if npm view "$PACKAGE_NAME" version >/dev/null 2>&1; then
             echo "Package $PACKAGE_NAME exists on npmjs"
             echo "exists=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.14'
+          node-version: '24.14.1'
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -25,7 +25,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.github-environment }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Initial publish with token
         if: steps.package-exists.outputs.exists != 'true'
         env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
           PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: npm-publish
+    secrets:
+      NPM_TOKEN:
+        required: true
+      NPM_TOTP_SECRET:
+        required: true
 
 permissions:
   contents: read
@@ -36,7 +41,7 @@ jobs:
           node-version: '22.14'
           registry-url: https://registry.npmjs.org
 
-      - name: Setup
+      - name: Install dependencies
         run: |
           npm install -g npm@latest
           sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
@@ -73,8 +78,8 @@ jobs:
         run: |
           set -euo pipefail
           otp="$(oathtool --base32 --totp "$NPM_TOTP_SECRET")"
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-          npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --otp "$otp"
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --access public --otp "$otp"
 
       - name: Configure trusted publisher
         env:

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -128,7 +128,7 @@ jobs:
                     + ($e | map("  current: repository=\(.claims.repository) workflow=\(.claims.workflow_ref.file) environment=\(.claims.environment)"))
                     + ["  expected: repository=\($repo) workflow=\($wf) environment=\($env)"]
                   else
-                    ["No trusted publisher configured for \($pkg)"]
+                    ["No trusted publisher configured for \($pkg). Configuring now."]
                   end
                 ),
                 ids: ($e | map(.id // empty)),
@@ -144,4 +144,5 @@ jobs:
           done < <(jq -r '.ids[]' <<<"$plan")
 
           curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$(jq -c '.body' <<<"$plan")"
+          echo
           echo "Trusted publisher for $PACKAGE_NAME configured successfully"

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -1,149 +1,52 @@
 # Publish an NPM package with trusted publishing (OIDC)
 
-A reusable workflow that bootstraps npm trusted publishing: it publishes **new** packages with a token, and configures the trusted publisher for all packages. Ongoing OIDC publishes should be handled by the parent workflow.
+A workflow for bootstrapping npm trusted publishing on the **public** Zendesk NPM packages. For packages not yet on npm, it performs an initial token-based publish. It then configures the npm trusted publisher for the package. Ongoing publishes use OIDC in the caller workflow.
 
-This workflow does not build, test, or validate the package. The parent workflow should validate `package.json` in the caller repository before calling this reusable workflow.
-
-`actions/checkout` checks out the **caller repository**, not `zendesk/gw`.
+This requires a `package.json` or similar configured for publishing in the caller repository.
 
 ## Workflow file
 
+This is the location of the workflow file relative to this repository:
+
 `.github/workflows/npm-trusted-publication.yml`
 
-Call it from your repository with:
+To call it from your repository you'll need to use:
 
 `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main`
-
-## Requirements
-
-- Node.js `>= 22.14`
-- npm CLI `>= 11.5.1` (installed automatically)
-- A GitHub environment (default: `npm-publish`) on the **parent workflow's OIDC publish job**
-- `secrets: inherit` in the caller workflow (repo/org secrets are not passed automatically)
-- `permissions.id-token: write` in the parent workflow that performs OIDC publish
-
-For packages that do not exist on npm yet, the workflow performs an initial token-based publish before configuring the trusted publisher. Existing packages only get trusted publisher configuration — publish is handled separately by the parent workflow.
 
 ## Required inputs
 
 | Input | Description |
 | --- | --- |
-| `package-name` | npm package name to publish |
-| `package-json-file-path` | Relative path to `package.json` (default: `package.json`) |
-| `publish-workflow` | Parent workflow filename, for example `publish.yml` |
-| `repository` | Parent repository in `owner/repo` format |
-| `github-environment` | GitHub environment name registered with npm trusted publishing (default: `npm-publish`). Used only in the trust API claim — this reusable workflow does not bind to that environment. |
+| `package-name` | required, npm package name |
+| `publish-workflow` | required, caller workflow filename, for example `publish.yml` |
+| `repository` | required, caller repository in `owner/repo` format |
+| `package-json-file-path` | optional, default `package.json`, relative path to `package.json` |
+| `github-environment` | optional, default `npm-publish`, GitHub environment registered with npm trusted publishing |
+| `secrets.NPM_TOKEN` | required, repository secret containing the NPM API key |
+| `secrets.NPM_TOTP_DEVICE` | required, organization secret containing the NPM 2FA TOTP code |
 
-## Required secrets
+## How to use
 
-Pass secrets with `secrets: inherit` in the caller workflow.
+Create a workflow in your repository that calls this reusable workflow. See the example below.
 
-Secrets are resolved from the **caller repository** (and organization), not from `zendesk/gw`. A secret stored only on `gw` is not available when another repository calls this workflow.
-
-### Repository secrets (per publishing repo)
-
-Add these as **repository secrets** on each repo that calls this workflow (for example `zendesk/npmjs-release-test`):
-
-| Secret | Description |
-| --- | --- |
-| `NPM_TOKEN` | NPM API token for initial publish and trusted publisher API calls (`zd-svc-npmjs`) |
-| `NPM_TOTP_DEVICE` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish) |
-
-Repository secrets must **not** be restricted to an environment only. If `NPM_TOKEN` is limited to the `npm-publish` environment, the caller job cannot access it (reusable workflow caller jobs cannot declare `environment:`).
-
-Request values via `#ask-packaging`.
-
-### Organization secrets (alternative)
-
-`NPM_TOTP_DEVICE` is often an organization secret shared across publishing repos. `NPM_TOKEN` can be configured the same way if you prefer not to duplicate secrets per repository.
-
-Subsequent publishes use OIDC in the parent workflow and do not require `NPM_TOKEN`.
-
-## Trusted publisher configuration
-
-Trusted publisher setup uses the npm registry API:
-
-```
-POST https://registry.npmjs.org/-/package/{package}/trust
-Authorization: Bearer $NPM_TOKEN
-npm-otp: $otp
-```
+The caller workflow should use `permissions.id-token: write` for OIDC publishes. Set `environment: npm-publish` on the job that performs OIDC publish.
 
 ## Example usage
 
+Here is an example workflow that bootstraps trusted publishing:
+
 ```yml
-name: publish package
-
-on:
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  id-token: write
+name: npm trusted publish
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22.14'
-      - run: npm ci
-      - run: npm test
-      - run: npm run build
-
-  publish:
-    needs: build
+  call-workflow:
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
     with:
       package-name: '@zendesk/example-package'
-      package-json-file-path: package.json
-      publish-workflow: publish-package.yml
+      publish-workflow: npm-trusted-publish.yml
       repository: ${{ github.repository }}
-      github-environment: npm-publish
 ```
-
-OIDC publishes in the parent workflow should use the environment directly:
-
-```yml
-  oidc-publish:
-    runs-on: ubuntu-latest
-    environment: npm-publish
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22.14'
-          registry-url: https://registry.npmjs.org
-      - run: npm publish --access public
-```
-
-## Validation rules
-
-`package-json-file-path` is validated before publish:
-
-- No absolute paths (`/`)
-- File must exist in the checked-out repository
-
-The `package-name` input must match the `name` field in `package.json`.
-
-## Workflow behavior
-
-### New package (not on npm)
-
-1. Validate inputs and `package.json`
-2. Publish to npm using `NPM_TOKEN` and `--otp`
-3. Configure trusted publisher via `POST /-/package/{package}/trust` with `npm-otp` header
-
-### Existing package (already on npm)
-
-1. Validate inputs and `package.json`
-2. Configure trusted publisher via npm registry API if not already configured
-3. Publish via OIDC in the parent workflow (not in this reusable workflow)
-
-### More Support 
-
-`#ask-packaging`

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -1,0 +1,115 @@
+# Publish an NPM package with trusted publishing (OIDC)
+
+A reusable workflow that bootstraps npm trusted publishing: it publishes **new** packages with a token, and configures the trusted publisher for all packages. Ongoing OIDC publishes should be handled by the parent workflow.
+
+This workflow does not build, test, or validate the package. The parent workflow should validate `package.json` in the caller repository before calling this reusable workflow.
+
+`actions/checkout` checks out the **caller repository**, not `zendesk/gw`.
+
+## Workflow file
+
+`.github/workflows/npm-trusted-publication.yml`
+
+Call it from your repository with:
+
+`zendesk/gw/.github/workflows/npm-trusted-publication.yml@main`
+
+## Requirements
+
+- Node.js `>= 22.14`
+- npm CLI `>= 11.5.1` (installed automatically)
+- A GitHub environment (default: `npm-publish`) in the parent repository
+- `permissions.id-token: write` in the parent workflow that performs OIDC publish
+
+For packages that do not exist on npm yet, the workflow performs an initial token-based publish before configuring the trusted publisher. Existing packages only get trusted publisher configuration — publish is handled separately by the parent workflow.
+
+## Required inputs
+
+| Input | Description |
+| --- | --- |
+| `package-name` | npm package name to publish |
+| `package-json-file-path` | Relative path to `package.json` (default: `package.json`) |
+| `publish-workflow` | Parent workflow filename, for example `publish.yml` |
+| `repository` | Parent repository in `owner/repo` format |
+| `github-environment` | GitHub environment name (default: `npm-publish`) |
+
+## Required secrets
+
+| Secret | Description |
+| --- | --- |
+| `NPM_TOKEN` | NPM API token for initial publish and trusted publisher API calls (`zd-svc-npmjs`) |
+| `NPM_TOTP_SECRET` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish) |
+
+Subsequent publishes use OIDC in the parent workflow and do not require `NPM_TOKEN`.
+
+## Trusted publisher configuration
+
+Trusted publisher setup uses the npm registry API:
+
+```
+POST https://registry.npmjs.org/-/package/{package}/trust
+Authorization: Bearer $NPM_TOKEN
+npm-otp: $otp
+```
+
+## Example usage
+
+```yml
+name: publish package
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.14'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
+  publish:
+    needs: build
+    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    with:
+      package-name: '@zendesk/example-package'
+      package-json-file-path: package.json
+      publish-workflow: publish-package.yml
+      repository: ${{ github.repository }}
+      github-environment: npm-publish
+```
+
+## Validation rules
+
+`package-json-file-path` is validated before publish:
+
+- No absolute paths (`/`)
+- File must exist in the checked-out repository
+
+The `package-name` input must match the `name` field in `package.json`.
+
+## Workflow behavior
+
+### New package (not on npm)
+
+1. Validate inputs and `package.json`
+2. Publish to npm using `NPM_TOKEN` and `--otp`
+3. Configure trusted publisher via `POST /-/package/{package}/trust` with `npm-otp` header
+
+### Existing package (already on npm)
+
+1. Validate inputs and `package.json`
+2. Configure trusted publisher via npm registry API if not already configured
+3. Publish via OIDC in the parent workflow (not in this reusable workflow)
+
+### More Support 
+
+`#ask-packaging`

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -79,12 +79,21 @@ jobs:
   publish:
     needs: build
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    secrets: inherit
     with:
       package-name: '@zendesk/example-package'
       package-json-file-path: package.json
       publish-workflow: publish-package.yml
       repository: ${{ github.repository }}
       github-environment: npm-publish
+```
+
+Or pass secrets explicitly:
+
+```yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
 ```
 
 ## Validation rules

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -36,11 +36,26 @@ For packages that do not exist on npm yet, the workflow performs an initial toke
 
 ## Required secrets
 
-Pass secrets with `secrets: inherit`.
+Pass secrets with `secrets: inherit` in the caller workflow.
+
+Secrets are resolved from the **caller repository** (and organization), not from `zendesk/gw`. A secret stored only on `gw` is not available when another repository calls this workflow.
+
+### Repository secrets (per publishing repo)
+
+Add these as **repository secrets** on each repo that calls this workflow (for example `zendesk/npmjs-release-test`):
 
 | Secret | Description |
 | --- | --- |
-| `NPM_TOTP_DEVICE` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish). Typically an organization secret. |
+| `NPM_TOKEN` | NPM API token for initial publish and trusted publisher API calls (`zd-svc-npmjs`) |
+| `NPM_TOTP_DEVICE` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish) |
+
+Repository secrets must **not** be restricted to an environment only. If `NPM_TOKEN` is limited to the `npm-publish` environment, the caller job cannot access it (reusable workflow caller jobs cannot declare `environment:`).
+
+Request values via `#ask-packaging`.
+
+### Organization secrets (alternative)
+
+`NPM_TOTP_DEVICE` is often an organization secret shared across publishing repos. `NPM_TOKEN` can be configured the same way if you prefer not to duplicate secrets per repository.
 
 Subsequent publishes use OIDC in the parent workflow and do not require `NPM_TOKEN`.
 

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -18,7 +18,8 @@ Call it from your repository with:
 
 - Node.js `>= 22.14`
 - npm CLI `>= 11.5.1` (installed automatically)
-- A GitHub environment (default: `npm-publish`) in the parent repository
+- A GitHub environment (default: `npm-publish`) on the **parent workflow's OIDC publish job**
+- `secrets: inherit` in the caller workflow (repo/org secrets are not passed automatically)
 - `permissions.id-token: write` in the parent workflow that performs OIDC publish
 
 For packages that do not exist on npm yet, the workflow performs an initial token-based publish before configuring the trusted publisher. Existing packages only get trusted publisher configuration — publish is handled separately by the parent workflow.
@@ -31,14 +32,15 @@ For packages that do not exist on npm yet, the workflow performs an initial toke
 | `package-json-file-path` | Relative path to `package.json` (default: `package.json`) |
 | `publish-workflow` | Parent workflow filename, for example `publish.yml` |
 | `repository` | Parent repository in `owner/repo` format |
-| `github-environment` | GitHub environment name (default: `npm-publish`) |
+| `github-environment` | GitHub environment name registered with npm trusted publishing (default: `npm-publish`). Used only in the trust API claim — this reusable workflow does not bind to that environment. |
 
 ## Required secrets
 
+Pass secrets with `secrets: inherit`.
+
 | Secret | Description |
 | --- | --- |
-| `NPM_TOKEN` | NPM API token for initial publish and trusted publisher API calls (`zd-svc-npmjs`) |
-| `NPM_TOTP_SECRET` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish) |
+| `NPM_TOTP_DEVICE` | NPM 2FA TOTP secret (`npm-otp` header for trust API, `--otp` for initial publish). Typically an organization secret. |
 
 Subsequent publishes use OIDC in the parent workflow and do not require `NPM_TOKEN`.
 
@@ -88,12 +90,20 @@ jobs:
       github-environment: npm-publish
 ```
 
-Or pass secrets explicitly:
+OIDC publishes in the parent workflow should use the environment directly:
 
 ```yml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_TOTP_SECRET: ${{ secrets.NPM_TOTP_SECRET }}
+  oidc-publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.14'
+          registry-url: https://registry.npmjs.org
+      - run: npm publish --access public
 ```
 
 ## Validation rules

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -1,52 +1,124 @@
-# Publish an NPM package with trusted publishing (OIDC)
+# NPM trusted publishing workflow
 
-A workflow for bootstrapping npm trusted publishing on the **public** Zendesk NPM packages. For packages not yet on npm, it performs an initial token-based publish. It then configures the npm trusted publisher for the package. Ongoing publishes use OIDC in the caller workflow.
+## Overview
 
-This requires a `package.json` or similar configured for publishing in the caller repository.
+This document describes the reusable GitHub Actions workflow for bootstrapping [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) on public Zendesk npm packages.
 
-## Workflow file
+The workflow performs one-time setup: it registers a trusted publisher on npm so that a designated GitHub Actions workflow in the caller repository can publish packages using short-lived OIDC credentials instead of a long-lived `NPM_TOKEN`.
 
-This is the location of the workflow file relative to this repository:
+This workflow does not build, test, or publish release versions. Release publishing remains the responsibility of a separate caller workflow.
+
+### Bootstrap behavior
+
+| Package state on npm | Actions performed |
+| --- | --- |
+| Not published | Set version to `0.0.0`, publish with `NPM_TOKEN` + TOTP, configure trusted publisher |
+| Already published | Skip publish; verify trusted publisher against inputs and reconfigure on mismatch |
+
+The `0.0.0` placeholder allows the caller workflow to publish the first real version (for example `1.0.0`) without a duplicate-version conflict.
+
+Re-running the workflow is idempotent: existing packages skip the placeholder publish. If the trusted publisher already matches the workflow inputs, it is left unchanged; otherwise it is reconfigured.
+
+### When to use
+
+- You are setting up OIDC publishing for a new or existing package for the first time
+- You need npm to trust a specific GitHub Actions workflow and environment in your repository
+- The package is new on npm and needs an initial `0.0.0` placeholder publish before trusted publishing can be configured
+- You renamed a release workflow, changed the GitHub environment, or moved the package to a different repository and need the trusted publisher updated
+
+## Prerequisites
+
+| Requirement | Notes |
+| --- | --- |
+| npm CLI ≥ 11.5.1 | Minimum version for trusted publishing; [npm documentation](https://docs.npmjs.com/trusted-publishers/) |
+| Node.js ≥ 22.14.0 | Recommended for caller OIDC publish workflows |
+| `package.json` | Must exist at the path specified by `package-json-file-path` |
+| Repository secrets | `NPM_TOKEN`, `NPM_TOTP_DEVICE` on the caller repository |
+| GitHub environment | `npm-publish` (or the value passed to `github-environment`) on the OIDC publish job |
+
+## Workflow reference
+
+**Path in this repository:**
 
 `.github/workflows/npm-trusted-publication.yml`
 
-To call it from your repository you'll need to use:
+**Reference from a caller repository:**
 
 `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main`
 
-## Required inputs
+## Inputs
 
-| Input | Description |
-| --- | --- |
-| `package-name` | required, npm package name |
-| `publish-workflow` | required, caller workflow filename, for example `publish.yml` |
-| `repository` | required, caller repository in `owner/repo` format |
-| `package-json-file-path` | optional, default `package.json`, relative path to `package.json` |
-| `github-environment` | optional, default `npm-publish`, GitHub environment registered with npm trusted publishing |
-| `secrets.NPM_TOKEN` | required, repository secret containing the NPM API key |
-| `secrets.NPM_TOTP_DEVICE` | required, organization secret containing the NPM 2FA TOTP code |
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `package-name` | Yes | — | npm package name |
+| `publish-workflow` | Yes | — | Caller workflow filename used for OIDC publishes (for example `publish.yml`). Must match exactly, including extension. |
+| `repository` | Yes | — | Caller repository in `owner/repo` format |
+| `package-json-file-path` | No | `package.json` | Relative path to `package.json` from the repository root |
+| `github-environment` | No | `npm-publish` | GitHub environment name registered with the npm trusted publisher |
 
-## How to use
+## Caller workflow requirements
 
-Create a workflow in your repository that calls this reusable workflow. See the example below.
+The workflow identified by `publish-workflow` must satisfy the following for OIDC release publishes:
 
-The caller workflow should use `permissions.id-token: write` for OIDC publishes. Set `environment: npm-publish` on the job that performs OIDC publish.
+- `permissions.id-token: write` at the workflow or job level
+- `environment` set to the value registered with npm (default: `npm-publish`)
+- npm CLI ≥ 11.5.1
+- No `NPM_TOKEN` on the OIDC publish step
 
-## Example usage
+## Configuration
 
-Here is an example workflow that bootstraps trusted publishing:
+1. Add `NPM_TOKEN` and `NPM_TOTP_DEVICE` repository secrets to the caller repository.
+2. Create a workflow that invokes `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main`.
+3. Pass `package-name`, `publish-workflow`, `repository`, and optionally `package-json-file-path`.
+
+## Example: single package
 
 ```yml
-name: npm trusted publish
+name: bootstrap npm trusted publishing
+
+on:
 
 jobs:
-  call-workflow:
+  bootstrap:
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+    secrets: inherit
     with:
       package-name: '@zendesk/example-package'
-      publish-workflow: npm-trusted-publish.yml
+      publish-workflow: publish.yml
       repository: ${{ github.repository }}
 ```
+
+Use `contents: write` only when the workflow modifies the repository (for example version bumps or release creation).
+
+## Example: multiple packages
+
+Each npm package requires a separate trusted publisher registration. Invoke the bootstrap workflow once per package with distinct `package-name` and `package-json-file-path` values.
+
+```yml
+name: bootstrap npm trusted publishing
+
+on:
+
+jobs:
+  bootstrap:
+    strategy:
+      matrix:
+        include:
+          - package-name: '@zendesk/package-a'
+            package-json-file-path: packages/package-a/package.json
+          - package-name: '@zendesk/package-b'
+            package-json-file-path: packages/package-b/package.json
+    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    secrets: inherit
+    with:
+      package-name: ${{ matrix.package-name }}
+      package-json-file-path: ${{ matrix.package-json-file-path }}
+      publish-workflow: publish.yml
+      repository: ${{ github.repository }}
+```
+
+After bootstrap completes, the OIDC publish workflow is responsible for building and publishing each package at its release version.
+
+## References
+
+- [npm trusted publishers (npm)](https://docs.npmjs.com/trusted-publishers/)


### PR DESCRIPTION
## Summary

Adds a reusable workflow to bootstrap npm trusted publishing (OIDC) for Zendesk packages.

Consumer repos call `zendesk/gw/.github/workflows/npm-trusted-publication.yml` to:

- New packages: first publish with NPM_TOKEN + TOTP, then register a trusted publisher
- Existing packages: register a trusted publisher only

Trusted publisher setup uses the npm registry HTTP API (`POST /-/package/{package}/trust`) with the `npm-otp` header, not the `npm trust` CLI.

## What's included

- `.github/workflows/npm-trusted-publication.yml`
- `npm-trusted-publication/README.md`

## Flow
Common:
1. Validate inputs

New package:
1. npm publish --otp
1. Configure trusted publisher via registry API

Existing package:
2. Configure trusted publisher if GET returns empty

## Example

```
jobs:
  publish:
    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
    secrets:
      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
      NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
    with:
      package-name: '@zendesk/example-package'
      package-json-file-path: package.json
      publish-workflow: publish-package.yml
      repository: ${{ github.repository }}
      github-environment: npm-publish
```
      
### Testing

##### New package (not on npm):
https://github.com/zendesk/npmjs-release-test/actions/runs/28021214653/job/82937717575

<img width="2986" height="1160" alt="image" src="https://github.com/user-attachments/assets/cbda7a8f-a66b-4478-88f5-eb5102aa4294" />

Trust configured:

<img width="2974" height="346" alt="image" src="https://github.com/user-attachments/assets/6ff721aa-8262-40ac-a6dd-b8b7483ab764" />

##### Existing Package with trust
https://github.com/zendesk/npmjs-release-test/actions/runs/28022024119/job/82940443859

Trust already configured:

<img width="3010" height="246" alt="image" src="https://github.com/user-attachments/assets/984daa2c-9a14-44ad-9238-15f4a2dfc861" />


##### Existing package without trust:
https://github.com/zendesk/npmjs-release-test/actions/runs/28022302027/job/82941375323

Trust configured:

<img width="2994" height="760" alt="image" src="https://github.com/user-attachments/assets/f7e59141-665c-480f-b2fa-d6735a5191f9" />

#### Trust configuration updation

https://github.com/zendesk/npmjs-release-test/actions/runs/28022461810/job/82941913640

<img width="2960" height="430" alt="image" src="https://github.com/user-attachments/assets/86e6a511-f5e6-4995-8f2e-d15eec5b6d54" />

Validation failures:
- [x] Absolute package-json-file-path fails validation

https://github.com/zendesk/npmjs-release-test/actions/runs/27937318949/job/82662043474
<img width="2630" height="242" alt="image" src="https://github.com/user-attachments/assets/71e4ce37-dc10-4942-b714-81e1d2cb4016" />

- [x] package-name mismatch with package.json name fails validation

https://github.com/zendesk/npmjs-release-test/actions/runs/27937201556/job/82661640527
<img width="2566" height="228" alt="image" src="https://github.com/user-attachments/assets/3e1886be-b2d7-4c85-89c6-2008d53cd1b4" />

