### PR TITLE
fix: enforce github environment before executing the trusted publisher workflow

### DIFF
--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       github-environment:
-        required: false
+        required: true
         type: string
         default: npm-publish
     secrets:

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.github-environment }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:


### PR DESCRIPTION
## Description

This PR enforces github environment before executing this workflow. To enhace security of the workflow, this configuration is required. 

