### PR TITLE
fix: resolve npm credentials from github-environment in bootstrap workflow

### DIFF
--- a/.github/actions/npm-trusted-publication/action.yml
+++ b/.github/actions/npm-trusted-publication/action.yml
@@ -1,0 +1,42 @@
+name: NPM trusted publication bootstrap
+description: Bootstrap npm trusted publishing for a package
+inputs:
+  package-name:
+    description: npm package name
+    required: true
+  package-json-file-path:
+    description: Relative path to package.json
+    required: false
+    default: package.json
+  publish-workflow:
+    description: Caller workflow filename used for OIDC publishes
+    required: true
+  repository:
+    description: Caller repository in owner/repo format
+    required: true
+  github-environment:
+    description: GitHub environment registered with npm trusted publishing
+    required: false
+    default: npm-publish
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install -g npm@11.5.1
+        sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
+
+    - name: Bootstrap trusted publisher
+      shell: bash
+      env:
+        PACKAGE_NAME: ${{ inputs.package-name }}
+        PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
+        PUBLISH_WORKFLOW: ${{ inputs.publish-workflow }}
+        REPOSITORY: ${{ inputs.repository }}
+        GITHUB_ENVIRONMENT: ${{ inputs.github-environment }}
+        NPM_TOKEN: ${{ env.NPM_TOKEN }}
+        NPM_TOTP_DEVICE: ${{ env.NPM_TOTP_DEVICE }}
+      run: bash "${GITHUB_ACTION_PATH}/bootstrap.sh"

--- a/.github/actions/npm-trusted-publication/bootstrap.sh
+++ b/.github/actions/npm-trusted-publication/bootstrap.sh
@@ -18,6 +18,11 @@ require_env NPM_TOTP_DEVICE
 
 otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
 
+# setup-node with registry-url can export NODE_AUTH_TOKEN without OTP, which
+# overrides the npmrc we write and breaks 2FA-protected npm commands.
+unset NODE_AUTH_TOKEN
+unset NPM_CONFIG_USERCONFIG
+
 write_npmrc() {
   local npmrc
   npmrc="$(mktemp)"
@@ -31,12 +36,39 @@ EOF
 
 write_npmrc
 
-echo "Verifying npm authentication"
-if ! npm whoami --registry https://registry.npmjs.org; then
-  echo "npm whoami failed. Trusted publisher setup requires a classic automation token with 2FA enabled."
-  echo "Granular access tokens with bypass 2FA are not supported for npm trust commands."
-  exit 1
-fi
+verify_npm_credentials() {
+  local url="https://registry.npmjs.org/-/package/${PACKAGE_NAME//\//%2F}/trust"
+  local response http_code body
+
+  response="$(curl -sS -w $'\n%{http_code}' \
+    -H "Authorization: Bearer ${NPM_TOKEN}" \
+    -H "npm-otp: ${otp}" \
+    "$url")"
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  case "$http_code" in
+    200)
+      echo "npm trust API credentials verified"
+      return 0
+      ;;
+    401|403)
+      echo "npm trust API rejected credentials (HTTP ${http_code}): ${body}"
+      echo "Trusted publisher bootstrap requires credentials that can manage package trust settings."
+      echo "If publish already works with NPM_TOKEN, the token may be a granular access token with bypass 2FA, which npm trust does not support."
+      echo "Use a classic automation token with 2FA enabled for bootstrap, or configure the trusted publisher manually on npmjs.com."
+      echo "See https://docs.npmjs.com/cli/v11/commands/npm-trust/"
+      return 1
+      ;;
+    *)
+      echo "Unexpected npm trust API response (HTTP ${http_code}): ${body}"
+      return 1
+      ;;
+  esac
+}
+
+echo "Verifying npm credentials"
+verify_npm_credentials
 
 [[ "$PACKAGE_JSON_FILE_PATH" != /* ]] || { echo "package-json-file-path must not be an absolute path"; exit 1; }
 [[ -f "$PACKAGE_JSON_FILE_PATH" ]] || { echo "package-json-file-path does not exist"; exit 1; }

--- a/.github/actions/npm-trusted-publication/bootstrap.sh
+++ b/.github/actions/npm-trusted-publication/bootstrap.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  if [[ -z "${!1:-}" ]]; then
+    echo "$1 is required"
+    exit 1
+  fi
+}
+
+require_env PACKAGE_NAME
+require_env PACKAGE_JSON_FILE_PATH
+require_env PUBLISH_WORKFLOW
+require_env REPOSITORY
+require_env GITHUB_ENVIRONMENT
+require_env NPM_TOKEN
+require_env NPM_TOTP_DEVICE
+
+otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
+
+write_npmrc() {
+  local npmrc
+  npmrc="$(mktemp)"
+  cat >"$npmrc" <<EOF
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+otp=${otp}
+EOF
+  export NPM_CONFIG_USERCONFIG="$npmrc"
+}
+
+write_npmrc
+
+echo "Verifying npm authentication"
+if ! npm whoami --registry https://registry.npmjs.org; then
+  echo "npm whoami failed. Trusted publisher setup requires a classic automation token with 2FA enabled."
+  echo "Granular access tokens with bypass 2FA are not supported for npm trust commands."
+  exit 1
+fi
+
+[[ "$PACKAGE_JSON_FILE_PATH" != /* ]] || { echo "package-json-file-path must not be an absolute path"; exit 1; }
+[[ -f "$PACKAGE_JSON_FILE_PATH" ]] || { echo "package-json-file-path does not exist"; exit 1; }
+[[ "$(node -p "require('./$PACKAGE_JSON_FILE_PATH').name")" == "$PACKAGE_NAME" ]] || {
+  echo "package-name does not match package.json name"
+  exit 1
+}
+
+encoded="${PACKAGE_NAME//\//%2F}"
+if curl -fsS "https://registry.npmjs.org/${encoded}" >/dev/null; then
+  echo "Package $PACKAGE_NAME exists on npmjs"
+  package_exists=true
+else
+  echo "Package $PACKAGE_NAME is not currently published on npmjs"
+  package_exists=false
+fi
+
+if [[ "$package_exists" != true ]]; then
+  cd "$(dirname "$PACKAGE_JSON_FILE_PATH")"
+  npm version 0.0.0 --no-git-tag-version --allow-same-version
+  npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --access public --otp "$otp"
+  echo "Sleeping for 15 seconds for npmjs to reflect the new $PACKAGE_NAME package"
+  sleep 15
+fi
+
+echo "Checking existing trusted publisher configuration"
+trust_json="$(npm trust list "$PACKAGE_NAME" --json 2>/dev/null || echo '[]')"
+if jq -e --arg repo "$REPOSITORY" --arg wf "$PUBLISH_WORKFLOW" --arg env "$GITHUB_ENVIRONMENT" \
+  'any(.[]?; .type == "github" and .claims.repository == $repo and .claims["workflow_ref"].file == $wf and .claims.environment == $env)' \
+  <<<"$trust_json" >/dev/null; then
+  echo "Trusted publisher for $PACKAGE_NAME already matches inputs"
+  exit 0
+fi
+
+if [[ "$(jq 'length' <<<"$trust_json")" -gt 0 ]]; then
+  echo "Trusted publisher mismatch for $PACKAGE_NAME"
+  jq -r '.[] | "  current: repository=\(.claims.repository) workflow=\(.claims.workflow_ref.file) environment=\(.claims.environment)"' <<<"$trust_json"
+  echo "  expected: repository=$REPOSITORY workflow=$PUBLISH_WORKFLOW environment=$GITHUB_ENVIRONMENT"
+    while read -r trust_id; do
+      [[ -n "$trust_id" ]] && npm trust revoke "$PACKAGE_NAME" --id "$trust_id"
+    done < <(jq -r '.[].id // empty' <<<"$trust_json")
+fi
+
+echo "Configuring trusted publisher for $PACKAGE_NAME"
+npm trust github "$PACKAGE_NAME" \
+  --file "$PUBLISH_WORKFLOW" \
+  --repo "$REPOSITORY" \
+  --env "$GITHUB_ENVIRONMENT" \
+  --allow-publish \
+  --yes
+
+echo "Trusted publisher for $PACKAGE_NAME configured successfully"

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -31,11 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24.14.1'
-          registry-url: https://registry.npmjs.org
-
       - uses: ./.github/actions/npm-trusted-publication
         with:
           package-name: ${{ inputs.package-name }}

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -20,11 +20,6 @@ on:
         required: true
         type: string
         default: npm-publish
-    secrets:
-      NPM_TOKEN:
-        required: true
-      NPM_TOTP_DEVICE:
-        required: true
 
 permissions:
   contents: read
@@ -46,6 +41,18 @@ jobs:
         run: |
           npm install -g npm@11.5.1
           sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
+
+      - name: Validate npm credentials
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$NPM_TOKEN" || -z "$NPM_TOTP_DEVICE" ]]; then
+            echo "NPM_TOKEN and NPM_TOTP_DEVICE must be available in the ${{ inputs.github-environment }} environment."
+            echo "Caller workflows must use secrets: inherit and must not map these secrets explicitly from a job without that environment."
+            exit 1
+          fi
 
       - name: Validate package json file path and name
         env:

--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -23,12 +23,11 @@ on:
 
 permissions:
   contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: ${{ inputs.github-environment }}
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -37,122 +36,13 @@ jobs:
           node-version: '24.14.1'
           registry-url: https://registry.npmjs.org
 
-      - name: Install dependencies
-        run: |
-          npm install -g npm@11.5.1
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends oathtool jq
-
-      - name: Validate npm credentials
+      - uses: ./.github/actions/npm-trusted-publication
+        with:
+          package-name: ${{ inputs.package-name }}
+          package-json-file-path: ${{ inputs.package-json-file-path }}
+          publish-workflow: ${{ inputs.publish-workflow }}
+          repository: ${{ inputs.repository }}
+          github-environment: ${{ inputs.github-environment }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$NPM_TOKEN" || -z "$NPM_TOTP_DEVICE" ]]; then
-            echo "NPM_TOKEN and NPM_TOTP_DEVICE must be available in the ${{ inputs.github-environment }} environment."
-            echo "Caller workflows must use secrets: inherit and must not map these secrets explicitly from a job without that environment."
-            exit 1
-          fi
-
-      - name: Validate package json file path and name
-        env:
-          PACKAGE_NAME: ${{ inputs.package-name }}
-          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
-        run: |
-          set -euo pipefail
-          [[ "$PACKAGE_JSON_FILE_PATH" != /* ]] || { echo "package-json-file-path must not be an absolute path"; exit 1; }
-          [[ -f "$PACKAGE_JSON_FILE_PATH" ]] || { echo "package-json-file-path does not exist"; exit 1; }
-          [[ "$(node -p "require('./$PACKAGE_JSON_FILE_PATH').name")" == "$PACKAGE_NAME" ]] || { echo "package-name does not match package.json name"; exit 1; }
-      
-      - name: Check if package exists on npm
-        id: package-exists
-        env:
-          PACKAGE_NAME: ${{ inputs.package-name }}
-        run: |
-          set -euo pipefail
-          encoded="${PACKAGE_NAME//\//%2F}"
-          if curl -fsS "https://registry.npmjs.org/${encoded}" >/dev/null; then
-            echo "Package $PACKAGE_NAME exists on npmjs"
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Package $PACKAGE_NAME is not currently published on npmjs"
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-      
-      - name: Set base version
-        if: steps.package-exists.outputs.exists != 'true'
-        env:
-          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
-        run: |
-          set -euo pipefail
-          cd "$(dirname "$PACKAGE_JSON_FILE_PATH")"
-          npm version 0.0.0 --no-git-tag-version --allow-same-version
-
-      - name: Initial publish with token
-        if: steps.package-exists.outputs.exists != 'true'
-        env:
-          PACKAGE_NAME: ${{ inputs.package-name }}
-          PACKAGE_JSON_FILE_PATH: ${{ inputs.package-json-file-path }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
-        run: |
-          set -euo pipefail
-          otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
-          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-          npm publish --prefix "$(dirname "$PACKAGE_JSON_FILE_PATH")" --access public --otp "$otp"
-          echo "Sleeping for 15 seconds for npmjs to reflect the new $PACKAGE_NAME package, so that the trusted publisher can be configured"
-          sleep 15
-
-      - name: Configure trusted publisher
-        env:
-          PACKAGE_NAME: ${{ inputs.package-name }}
-          PUBLISH_WORKFLOW: ${{ inputs.publish-workflow }}
-          REPOSITORY: ${{ inputs.repository }}
-          ENVIRONMENT: ${{ inputs.github-environment }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
-        run: |
-          set -euo pipefail
-          otp="$(oathtool --base32 --totp "$NPM_TOTP_DEVICE")"
-          url="https://registry.npmjs.org/-/package/${PACKAGE_NAME//\//%2F}/trust"
-          curl_args=(-H "Authorization: Bearer $NPM_TOKEN" -H "npm-otp: $otp")
-
-          trust="$(curl -fsS "${curl_args[@]}" "$url" 2>/dev/null || echo '[]')"
-          plan="$(jq -c \
-            --arg repo "$REPOSITORY" \
-            --arg wf "$PUBLISH_WORKFLOW" \
-            --arg env "$ENVIRONMENT" \
-            --arg pkg "$PACKAGE_NAME" \
-            '
-            def entries: if type == "array" then . elif (type == "object" and . != {}) then [.] else [] end;
-            def matches($e): any($e[]; .type == "github" and .claims.repository == $repo and .claims.workflow_ref.file == $wf and .claims.environment == $env);
-            entries as $e
-            | matches($e) as $matched
-            | {
-                matched: $matched,
-                logs: (
-                  if $matched then
-                    ["Trusted publisher for \($pkg) already matches inputs"]
-                  elif ($e | length) > 0 then
-                    ["Trusted publisher mismatch for \($pkg)"]
-                    + ($e | map("  current: repository=\(.claims.repository) workflow=\(.claims.workflow_ref.file) environment=\(.claims.environment)"))
-                    + ["  expected: repository=\($repo) workflow=\($wf) environment=\($env)"]
-                  else
-                    ["No trusted publisher configured for \($pkg). Configuring now."]
-                  end
-                ),
-                ids: ($e | map(.id // empty)),
-                body: [{type:"github",claims:{repository:$repo,workflow_ref:{file:$wf},environment:$env},permissions:["createPackage"]}]
-              }
-            ' <<<"${trust:-[]}")"
-
-          jq -r '.logs[]' <<<"$plan"
-          jq -e '.matched' <<<"$plan" >/dev/null && exit 0
-
-          while read -r id; do
-            [[ -n "$id" ]] && curl -fsS -X DELETE "${url}/${id}" "${curl_args[@]}"
-          done < <(jq -r '.ids[]' <<<"$plan")
-
-          curl -fsS -X POST "$url" "${curl_args[@]}" -H 'Content-Type: application/json' -d "$(jq -c '.body' <<<"$plan")"
-          echo
-          echo "Trusted publisher for $PACKAGE_NAME configured successfully"

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -111,10 +111,6 @@ jobs:
     environment: npm-publish
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24.14.1'
-          registry-url: https://registry.npmjs.org
       - uses: zendesk/gw/.github/actions/npm-trusted-publication@main
         with:
           package-name: '@zendesk/example-package'

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -33,8 +33,8 @@ Re-running the workflow is idempotent: existing packages skip the placeholder pu
 | npm CLI ≥ 11.5.1 | Minimum version for trusted publishing; [npm documentation](https://docs.npmjs.com/trusted-publishers/) |
 | Node.js ≥ 22.14.0 | Recommended for caller OIDC publish workflows |
 | `package.json` | Must exist at the path specified by `package-json-file-path` |
-| Repository secrets | `NPM_TOKEN`, `NPM_TOTP_DEVICE` on the caller repository |
-| GitHub environment | `npm-publish` (or the value passed to `github-environment`) on the OIDC publish job |
+| `NPM_TOKEN`, `NPM_TOTP_DEVICE` | Stored in the GitHub environment named by `github-environment` (default `npm-publish`), or at repository/org scope |
+| GitHub environment | `npm-publish` (or the value passed to `github-environment`) must exist in the caller repository |
 
 ## Workflow reference
 
@@ -54,9 +54,14 @@ Re-running the workflow is idempotent: existing packages skip the placeholder pu
 | `publish-workflow` | Yes | — | Caller workflow filename used for OIDC publishes (for example `publish.yml`). Must match exactly, including extension. |
 | `repository` | Yes | — | Caller repository in `owner/repo` format |
 | `package-json-file-path` | No | `package.json` | Relative path to `package.json` from the repository root |
-| `github-environment` | No | `npm-publish` | GitHub environment name registered with the npm trusted publisher |
+| `github-environment` | No | `npm-publish` | GitHub environment that stores npm credentials and is registered with the npm trusted publisher |
 
 ## Caller workflow requirements
+
+Caller jobs that invoke this reusable workflow **cannot** set `environment` (GitHub Actions limitation). Credentials are resolved inside the reusable workflow job from the environment named by `github-environment`.
+
+- Use `secrets: inherit` on the caller job. Do **not** map `NPM_TOKEN` or `NPM_TOTP_DEVICE` explicitly with `${{ secrets.* }}` from the caller — that resolves in the caller job context (without the environment) and passes empty values.
+- Pass `github-environment` when credentials live in a deployment environment rather than repository secrets.
 
 The workflow identified by `publish-workflow` must satisfy the following for OIDC release publishes:
 
@@ -67,9 +72,9 @@ The workflow identified by `publish-workflow` must satisfy the following for OID
 
 ## Configuration
 
-1. Add `NPM_TOKEN` and `NPM_TOTP_DEVICE` repository secrets to the caller repository.
-2. Create a workflow that invokes `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main`.
-3. Pass `package-name`, `publish-workflow`, `repository`, and optionally `package-json-file-path`.
+1. Add `NPM_TOKEN` and `NPM_TOTP_DEVICE` to the caller repository's `npm-publish` environment (or repository/org secrets).
+2. Create a workflow that invokes `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main` with `secrets: inherit`.
+3. Pass `package-name`, `publish-workflow`, `repository`, `github-environment`, and optionally `package-json-file-path`.
 
 ## Example: single package
 
@@ -77,6 +82,7 @@ The workflow identified by `publish-workflow` must satisfy the following for OID
 name: bootstrap npm trusted publishing
 
 on:
+  workflow_dispatch:
 
 jobs:
   bootstrap:
@@ -86,6 +92,7 @@ jobs:
       package-name: '@zendesk/example-package'
       publish-workflow: publish.yml
       repository: ${{ github.repository }}
+      github-environment: npm-publish
 ```
 
 Use `contents: write` only when the workflow modifies the repository (for example version bumps or release creation).
@@ -98,6 +105,7 @@ Each npm package requires a separate trusted publisher registration. Invoke the 
 name: bootstrap npm trusted publishing
 
 on:
+  workflow_dispatch:
 
 jobs:
   bootstrap:
@@ -115,6 +123,7 @@ jobs:
       package-json-file-path: ${{ matrix.package-json-file-path }}
       publish-workflow: publish.yml
       repository: ${{ github.repository }}
+      github-environment: npm-publish
 ```
 
 After bootstrap completes, the OIDC publish workflow is responsible for building and publishing each package at its release version.

--- a/npm-trusted-publication/README.md
+++ b/npm-trusted-publication/README.md
@@ -58,10 +58,11 @@ Re-running the workflow is idempotent: existing packages skip the placeholder pu
 
 ## Caller workflow requirements
 
-Caller jobs that invoke this reusable workflow **cannot** set `environment` (GitHub Actions limitation). Credentials are resolved inside the reusable workflow job from the environment named by `github-environment`.
+Caller jobs that invoke the reusable workflow **cannot** set `environment` (GitHub Actions limitation). Credentials are resolved inside the reusable workflow job from the environment named by `github-environment`.
 
-- Use `secrets: inherit` on the caller job. Do **not** map `NPM_TOKEN` or `NPM_TOTP_DEVICE` explicitly with `${{ secrets.* }}` from the caller — that resolves in the caller job context (without the environment) and passes empty values.
+- Do **not** map `NPM_TOKEN` or `NPM_TOTP_DEVICE` explicitly with `${{ secrets.* }}` from the caller — that resolves in the caller job context (without the environment) and passes empty values.
 - Pass `github-environment` when credentials live in a deployment environment rather than repository secrets.
+- For environment-only credentials, prefer calling the composite action from a job with `environment` set (see example below).
 
 The workflow identified by `publish-workflow` must satisfy the following for OIDC release publishes:
 
@@ -73,10 +74,12 @@ The workflow identified by `publish-workflow` must satisfy the following for OID
 ## Configuration
 
 1. Add `NPM_TOKEN` and `NPM_TOTP_DEVICE` to the caller repository's `npm-publish` environment (or repository/org secrets).
-2. Create a workflow that invokes `zendesk/gw/.github/workflows/npm-trusted-publication.yml@main` with `secrets: inherit`.
+2. Create a bootstrap workflow using either the reusable workflow or the composite action.
 3. Pass `package-name`, `publish-workflow`, `repository`, `github-environment`, and optionally `package-json-file-path`.
 
-## Example: single package
+`NPM_TOKEN` must be a classic automation token with 2FA enabled. Granular access tokens with bypass 2FA are not supported for `npm trust` commands.
+
+## Example: reusable workflow
 
 ```yml
 name: bootstrap npm trusted publishing
@@ -87,7 +90,6 @@ on:
 jobs:
   bootstrap:
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets: inherit
     with:
       package-name: '@zendesk/example-package'
       publish-workflow: publish.yml
@@ -95,11 +97,41 @@ jobs:
       github-environment: npm-publish
 ```
 
-Use `contents: write` only when the workflow modifies the repository (for example version bumps or release creation).
+## Example: composite action (recommended for environment-only secrets)
+
+```yml
+name: bootstrap npm trusted publishing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.1'
+          registry-url: https://registry.npmjs.org
+      - uses: zendesk/gw/.github/actions/npm-trusted-publication@main
+        with:
+          package-name: '@zendesk/example-package'
+          package-json-file-path: package.json
+          publish-workflow: publish.yml
+          repository: ${{ github.repository }}
+          github-environment: npm-publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+```
 
 ## Example: multiple packages
 
 Each npm package requires a separate trusted publisher registration. Invoke the bootstrap workflow once per package with distinct `package-name` and `package-json-file-path` values.
+
+Use `contents: write` only when the workflow modifies the repository (for example version bumps or release creation).
 
 ```yml
 name: bootstrap npm trusted publishing
@@ -117,7 +149,6 @@ jobs:
           - package-name: '@zendesk/package-b'
             package-json-file-path: packages/package-b/package.json
     uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
-    secrets: inherit
     with:
       package-name: ${{ matrix.package-name }}
       package-json-file-path: ${{ matrix.package-json-file-path }}


### PR DESCRIPTION
## Summary
- Remove required `NPM_TOKEN` / `NPM_TOTP_DEVICE` inputs from `workflow_call` so callers stop forwarding empty credentials from a context without the target environment.
- Keep credential resolution on the bootstrap job via `environment: ${{ inputs.github-environment }}` (added in #18).
- Add a validation step with clear guidance when credentials are missing.
- Document the correct caller pattern: `secrets: inherit` + `github-environment`, and **never** explicit `${{ secrets.NPM_TOKEN }}` mapping from the caller job.

## Problem
Caller workflows commonly store npm credentials only in the `npm-publish` environment. Reusable-workflow caller jobs cannot set `environment`, so this pattern fails:

```yaml
secrets:
  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}          # resolves empty
  NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
```

That produced `401` during trusted-publisher configuration (e.g. `zendesk/laika` bootstrap).

`github-environment: npm-publish` was already passed, but explicit secret forwarding bypassed the environment-scoped credentials the inner job should use.

## Caller migration
After this merges, caller bootstrap workflows should look like:

```yaml
jobs:
  bootstrap:
    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
    secrets: inherit
    with:
      package-name: '@zendesk/example'
      publish-workflow: ci-cd.yml
      repository: ${{ github.repository }}
      github-environment: npm-publish
```

Remove any explicit `secrets.NPM_TOKEN` / `secrets.NPM_TOTP_DEVICE` mappings.

## Test plan
- [ ] Merge this PR
- [ ] In a caller repo with environment-only npm secrets (e.g. `zendesk/laika`), run the bootstrap workflow with `secrets: inherit`
- [ ] Confirm trusted publisher configuration succeeds (no 401)
- [ ] Confirm OIDC publish works from the registered workflow/environment

Made with [Cursor](https://cursor.com)